### PR TITLE
Refactor: Align SalaryComponent model with Phase 2 requirements

### DIFF
--- a/models/salaryComponent.model.js
+++ b/models/salaryComponent.model.js
@@ -13,19 +13,19 @@ module.exports = (sequelize, DataTypes) => {
       SalaryComponent.belongsTo(models.Tenant, {
         foreignKey: 'tenantId',
         as: 'tenant',
-        allowNull: false,
+        allowNull: true,
       });
 
       // For components calculated as a percentage of another component
-      SalaryComponent.belongsTo(models.SalaryComponent, {
-        foreignKey: 'basedOnComponentId',
-        as: 'basedOnComponent',
-        allowNull: true, // Null if not percentage-based or based on a fixed value/formula
-      });
-      SalaryComponent.hasMany(models.SalaryComponent, {
-        foreignKey: 'basedOnComponentId',
-        as: 'dependentComponents'
-      });
+      // SalaryComponent.belongsTo(models.SalaryComponent, {
+      //   foreignKey: 'basedOnComponentId',
+      //   as: 'basedOnComponent',
+      //   allowNull: true, // Null if not percentage-based or based on a fixed value/formula
+      // });
+      // SalaryComponent.hasMany(models.SalaryComponent, {
+      //   foreignKey: 'basedOnComponentId',
+      //   as: 'dependentComponents'
+      // });
 
       // This component might be part of many EmployeeSalary structures or PayrollItems
       // Example: (Assuming an EmployeeSalaryComponent join table or direct use in PayrollItem)
@@ -48,7 +48,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     tenantId: {
       type: DataTypes.UUID,
-      allowNull: false,
+      allowNull: true,
       references: { model: 'tenants', key: 'id' },
       onUpdate: 'CASCADE', onDelete: 'CASCADE',
     },
@@ -63,25 +63,26 @@ module.exports = (sequelize, DataTypes) => {
     calculation_type: { // How the component value is determined
       type: DataTypes.ENUM('fixed', 'percentage', 'formula'), // 'formula' might need custom logic
       allowNull: false,
+      defaultValue: 'fixed',
     },
     amount: { // Fixed amount for 'fixed' type, or default/base amount.
       type: DataTypes.DECIMAL(12, 2), // Precision 12, 2 decimal places
       allowNull: true, // Might be null if 'percentage' or complex 'formula'
     },
-    percentage: { // Percentage value if 'percentage' type
-      type: DataTypes.DECIMAL(5, 2), // e.g., 50.00 for 50%
-      allowNull: true, // Null if not 'percentage' type
-    },
-    basedOnComponentId: { // Self-referential FK for percentage calculations
-      type: DataTypes.UUID,
-      allowNull: true,
-      references: { model: 'salary_components', key: 'id' }, // Points to itself
-      onUpdate: 'CASCADE', onDelete: 'SET NULL', // Or 'RESTRICT'
-    },
-    formula_json: { // For 'formula' type, store parameters or steps as JSON
-      type: DataTypes.JSONB,
-      allowNull: true,
-    },
+    // percentage: { // Percentage value if 'percentage' type
+    //   type: DataTypes.DECIMAL(5, 2), // e.g., 50.00 for 50%
+    //   allowNull: true, // Null if not 'percentage' type
+    // },
+    // basedOnComponentId: { // Self-referential FK for percentage calculations
+    //   type: DataTypes.UUID,
+    //   allowNull: true,
+    //   references: { model: 'salary_components', key: 'id' }, // Points to itself
+    //   onUpdate: 'CASCADE', onDelete: 'SET NULL', // Or 'RESTRICT'
+    // },
+    // formula_json: { // For 'formula' type, store parameters or steps as JSON
+    //   type: DataTypes.JSONB,
+    //   allowNull: true,
+    // },
     is_taxable: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
@@ -92,7 +93,7 @@ module.exports = (sequelize, DataTypes) => {
       defaultValue: true,
       allowNull: false,
     },
-    is_default_component: { // Indicates if this is a system-provided default component
+    is_system_defined: { // Indicates if this is a system-provided default component
       type: DataTypes.BOOLEAN,
       defaultValue: false,
       allowNull: false,
@@ -111,7 +112,7 @@ module.exports = (sequelize, DataTypes) => {
     indexes: [
       { fields: ['tenant_id'] },
       { unique: true, fields: ['tenant_id', 'name'], name: 'unique_tenant_salary_component_name' },
-      { fields: ['based_on_component_id'] },
+      // { fields: ['based_on_component_id'] },
     ]
   });
 


### PR DESCRIPTION
This commit updates the SalaryComponent model to better support Phase 2 specifications:

- `tenantId` can now be NULL to distinguish system-defined components from tenant-specific ones. The association with Tenant has also been updated to allow NULL.
- Renamed `is_default_component` to `is_system_defined` for improved clarity, ensuring it's a boolean, defaults to false, and is not nullable.
- Set `defaultValue: 'fixed'` for the `calculation_type` field, as tenant-created components in Phase 2 are always of fixed calculation type.
- Commented out fields not used in Phase 2: `percentage`, `basedOnComponentId` (and its associations/index), and `formula_json`.

These changes ensure the model accurately reflects the data structure needed for differentiating system and tenant components and their configurations as per the defined project phases.