### PR TITLE
Fix: Resolve nested Router and ChakraProvider error

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ChakraProvider, Box, Heading, VStack } from '@chakra-ui/react';
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { Box, Heading, VStack } from '@chakra-ui/react'; // ChakraProvider removed
+import { Routes, Route, Link } from 'react-router-dom'; // BrowserRouter as Router removed
 import SalaryComponentsPage from '../features/salaryComponents/pages/SalaryComponentsPage'; // Corrected import path
 
 // Mock Dashboard and Settings components (replace with actual components)
@@ -9,11 +9,11 @@ const Settings = () => <Heading size="lg">Settings</Heading>;
 
 const App: React.FC = () => {
   return (
-    <ChakraProvider>
-      <Router>
-        <Box p={5}>
-          <nav>
-            <VStack spacing={4} align="stretch">
+    // ChakraProvider removed
+    // Router removed
+    <Box p={5}>
+      <nav>
+        <VStack spacing={4} align="stretch">
               <Link to="/">Dashboard</Link>
               <Link to="/salary-components">Salary Components</Link>
               <Link to="/settings">Settings</Link>
@@ -28,8 +28,8 @@ const App: React.FC = () => {
             </Routes>
           </Box>
         </Box>
-      </Router>
-    </ChakraProvider>
+    // Router removed
+    // ChakraProvider removed
   );
 };
 


### PR DESCRIPTION
I removed redundant Router and ChakraProvider components from `App.tsx`.

`index.tsx` already provides a top-level BrowserRouter and ChakraProvider for the application. The `App.tsx` component was unnecessarily wrapping its content in another Router and ChakraProvider, leading to the 'You cannot render a <Router> inside another <Router>' runtime error.

This change ensures that there's only a single instance of Router and ChakraProvider, as recommended by React Router and Chakra UI documentation, which should resolve the runtime error and ensure proper application behavior.