### PR TITLE
Update SalaryComponent model and types

### DIFF
--- a/backend/models/salaryComponent.model.js
+++ b/backend/models/salaryComponent.model.js
@@ -69,10 +69,14 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.DECIMAL(12, 2), // Precision 12, 2 decimal places
       allowNull: true, // Might be null if 'percentage' or complex 'formula'
     },
-    // percentage: { // Percentage value if 'percentage' type
-    //   type: DataTypes.DECIMAL(5, 2), // e.g., 50.00 for 50%
-    //   allowNull: true, // Null if not 'percentage' type
-    // },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true, // Or false, depending on requirements
+    },
+    percentage: { // Percentage value if 'percentage' type
+      type: DataTypes.DECIMAL(5, 2), // e.g., 50.00 for 50%
+      allowNull: true, // Null if not 'percentage' type
+    },
     // basedOnComponentId: { // Self-referential FK for percentage calculations
     //   type: DataTypes.UUID,
     //   allowNull: true,

--- a/src/types/salaryComponent.ts
+++ b/src/types/salaryComponent.ts
@@ -1,0 +1,28 @@
+export interface SalaryComponent {
+  id: string; // UUID
+  tenantId?: string | null; // UUID
+  name: string;
+  description?: string | null;
+  type: 'earning' | 'deduction';
+  calculation_type: 'fixed' | 'percentage' | 'formula';
+  amount?: number | null; // Decimal
+  percentage?: number | null; // Decimal
+  // basedOnComponentId?: string | null; // UUID
+  // formula_json?: any | null; // JSONB
+  is_taxable: boolean;
+  is_active: boolean;
+  is_system_defined: boolean;
+  payslip_display_order?: number | null;
+  component_code?: string | null;
+  is_cnss_subject: boolean;
+  is_amo_subject: boolean;
+  // order?: number | null;
+  createdAt?: string; // Date
+  updatedAt?: string; // Date
+  deletedAt?: string | null; // Date
+}
+
+export type SalaryComponentPayload = Omit<
+  SalaryComponent,
+  'id' | 'is_system_defined' | 'tenantId' | 'is_cnss_subject' | 'is_amo_subject' | 'component_code' | 'createdAt' | 'updatedAt' | 'deletedAt'
+>;


### PR DESCRIPTION
This commit updates the backend SalaryComponent model and defines the corresponding frontend type definitions.

Backend model changes (`backend/models/salaryComponent.model.js`):
- Uncommented the `percentage` field to allow for percentage-based salary components.
- Added a `description` field (`DataTypes.TEXT`) to store a textual description for a salary component.

Frontend type changes (`src/types/salaryComponent.ts`):
- Created a new file for `SalaryComponent` types.
- Defined the `SalaryComponent` interface, aligning with the updated backend model fields.
- Defined the `SalaryComponentPayload` type for create/update operations, omitting read-only and server-managed fields.