### PR TITLE
feat: Update Salary Component API and Modal for Calculation Types

### DIFF
--- a/frontend/src/features/salaryComponents/components/SalaryComponentModal.tsx
+++ b/frontend/src/features/salaryComponents/components/SalaryComponentModal.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+// frontend/src/features/salaryComponents/components/SalaryComponentModal.tsx
+import React, { useEffect, useState } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -13,13 +14,22 @@ import {
   Input,
   Select,
   Checkbox,
+  Textarea, // Added for description
+  VStack,   // Added for layout
+  NumberInput, // For numeric inputs
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
 } from '@chakra-ui/react';
+// Adjust the import path if your types file is, e.g., src/types/index.ts or src/types/salaryComponent.ts
+import { SalaryComponent, SalaryComponentFormData } from '../../../types/salaryComponent';
 
 interface SalaryComponentModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (component: any) => void; // Replace 'any' with a more specific type
-  component?: any; // Replace 'any' with a more specific type
+  onSave: (data: SalaryComponentFormData) => void;
+  component?: SalaryComponent; // This is the component being edited, if any
 }
 
 const SalaryComponentModal: React.FC<SalaryComponentModalProps> = ({
@@ -28,121 +38,208 @@ const SalaryComponentModal: React.FC<SalaryComponentModalProps> = ({
   onSave,
   component,
 }) => {
-  // State for form fields - initialize with component data if editing
-  const [name, setName] = React.useState(component?.name || '');
-  const [type, setType] = React.useState(component?.type || 'earning');
-  const [calculationType, setCalculationType] = React.useState(
-    component?.calculationType || 'fixed'
-  );
-  const [value, setValue] = React.useState(component?.value || '');
-  const [isTaxable, setIsTaxable] = React.useState(component?.isTaxable || false);
-  const [isCalculatedInCtc, setIsCalculatedInCtc] = React.useState(
-    component?.isCalculatedInCtc || false
-  );
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [type, setType] = useState<'earning' | 'deduction'>('earning');
+  const [calculationType, setCalculationType] = useState<'fixed' | 'percentage'>('fixed');
+  const [amount, setAmount] = useState<number | undefined>(undefined);
+  const [percentage, setPercentage] = useState<number | undefined>(undefined);
+  const [isTaxable, setIsTaxable] = useState(false);
+  const [payslipDisplayOrder, setPayslipDisplayOrder] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (isOpen) { // Only update form when modal is opened or component changes
+      if (component) {
+        setName(component.name);
+        setDescription(component.description || '');
+        setType(component.type);
+        if (component.calculation_type === 'fixed' || component.calculation_type === 'percentage') {
+          setCalculationType(component.calculation_type);
+        } else {
+          // Default to 'fixed' if backend sends 'formula', as modal doesn't support it yet
+          setCalculationType('fixed');
+        }
+        setAmount(component.calculation_type === 'fixed' ? (component.amount ?? undefined) : undefined);
+        setPercentage(component.calculation_type === 'percentage' ? (component.percentage ?? undefined) : undefined);
+        setIsTaxable(component.is_taxable);
+        setPayslipDisplayOrder(component.payslip_display_order ?? undefined);
+      } else {
+        // Reset form for "Add New"
+        setName('');
+        setDescription('');
+        setType('earning');
+        setCalculationType('fixed');
+        setAmount(undefined);
+        setPercentage(undefined);
+        setIsTaxable(false);
+        setPayslipDisplayOrder(undefined);
+      }
+    }
+  }, [component, isOpen]); // Rerun effect if component or isOpen changes
 
   const handleSubmit = () => {
-    const newComponent = {
+    const formData: SalaryComponentFormData = {
+      // id: component?.id, // ID should not be part of FormData for create/update like this. Backend handles ID.
+      // If it's for update, the ID is usually passed separately or as a URL param.
+      // For now, assuming onSave knows if it's an update via the presence of 'component' prop.
       name,
+      description: description.trim() === '' ? null : description.trim(),
       type,
-      calculationType,
-      value: parseFloat(value), // Ensure value is a number
-      isTaxable,
-      isCalculatedInCtc,
-      // Add other fields as necessary
+      calculation_type: calculationType,
+      is_taxable: isTaxable,
+      payslip_display_order: payslipDisplayOrder,
+      // amount and percentage are added conditionally below
     };
-    onSave(newComponent);
-    onClose(); // Close modal after saving
+
+    if (calculationType === 'fixed') {
+      formData.amount = amount ?? null;
+      formData.percentage = null;
+    } else if (calculationType === 'percentage') {
+      formData.percentage = percentage ?? null;
+      formData.amount = null;
+    }
+
+    onSave(formData);
+    onClose();
+  };
+
+  const handleCalculationTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newCalcType = e.target.value as 'fixed' | 'percentage';
+    setCalculationType(newCalcType);
+    if (newCalcType === 'fixed') {
+      setPercentage(undefined);
+    } else {
+      setAmount(undefined);
+    }
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} size="xl" scrollBehavior="inside">
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
-          {component ? 'Edit Salary Component' : 'Add Salary Component'}
+          {component ? 'Edit Salary Component' : 'Add New Salary Component'}
         </ModalHeader>
         <ModalCloseButton />
         <ModalBody pb={6}>
-          <FormControl isRequired>
-            <FormLabel>Name</FormLabel>
-            <Input
-              placeholder="Enter component name"
-              value={name}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setName(e.target.value)
-              }
-            />
-          </FormControl>
+          <VStack spacing={4}>
+            <FormControl isRequired>
+              <FormLabel>Name</FormLabel>
+              <Input
+                placeholder="e.g., Basic Salary, House Rent Allowance"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </FormControl>
 
-          <FormControl mt={4} isRequired>
-            <FormLabel>Type</FormLabel>
-            <Select
-              value={type}
-              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                setType(e.target.value)
-              }
-              placeholder="Select type"
-            >
-              <option value="earning">Earning</option>
-              <option value="deduction">Deduction</option>
-            </Select>
-          </FormControl>
+            <FormControl>
+              <FormLabel>Description (Optional)</FormLabel>
+              <Textarea
+                placeholder="Brief description of the component"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+            </FormControl>
 
-          <FormControl mt={4} isRequired>
-            <FormLabel>Calculation Type</FormLabel>
-            <Select
-              value={calculationType}
-              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                setCalculationType(e.target.value)
-              }
-              placeholder="Select calculation type"
-            >
-              <option value="fixed">Fixed</option>
-              <option value="percentage">Percentage</option>
-              {/* Add other calculation types as needed */}
-            </Select>
-          </FormControl>
+            <FormControl isRequired>
+              <FormLabel>Type</FormLabel>
+              <Select
+                value={type}
+                onChange={(e) => setType(e.target.value as 'earning' | 'deduction')}
+              >
+                <option value="earning">Earning</option>
+                <option value="deduction">Deduction</option>
+              </Select>
+            </FormControl>
 
-          <FormControl mt={4} isRequired>
-            <FormLabel>Value</FormLabel>
-            <Input
-              type="number"
-              placeholder="Enter value"
-              value={value}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setValue(e.target.value)
-              }
-            />
-          </FormControl>
+            <FormControl isRequired>
+              <FormLabel>Calculation Type</FormLabel>
+              <Select
+                value={calculationType}
+                onChange={handleCalculationTypeChange}
+              >
+                <option value="fixed">Fixed Amount</option>
+                <option value="percentage">Percentage</option>
+                {/* <option value="formula" disabled>Formula (Coming Soon)</option> */}
+              </Select>
+            </FormControl>
 
-          <FormControl mt={4}>
-            <Checkbox
-              isChecked={isTaxable}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setIsTaxable(e.target.checked)
-              }
-            >
-              Taxable
-            </Checkbox>
-          </FormControl>
+            {calculationType === 'fixed' && (
+              <FormControl isRequired>
+                <FormLabel>Default Amount</FormLabel>
+                 <NumberInput
+                    value={amount === undefined || amount === null ? '' : amount}
+                    onChange={(_valueAsString, valueAsNumber) => setAmount(isNaN(valueAsNumber) ? undefined : valueAsNumber)}
+                    min={0}
+                  >
+                    <NumberInputField placeholder="Enter fixed amount" />
+                    <NumberInputStepper>
+                      <NumberIncrementStepper />
+                      <NumberDecrementStepper />
+                    </NumberInputStepper>
+                  </NumberInput>
+              </FormControl>
+            )}
 
-          <FormControl mt={4}>
-            <Checkbox
-              isChecked={isCalculatedInCtc}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setIsCalculatedInCtc(e.target.checked)
-              }
-            >
-              Calculated in CTC
-            </Checkbox>
-          </FormControl>
+            {calculationType === 'percentage' && (
+              <FormControl isRequired>
+                <FormLabel>Default Percentage (%)</FormLabel>
+                 <NumberInput
+                    value={percentage === undefined || percentage === null ? '' : percentage}
+                    onChange={(_valueAsString, valueAsNumber) => setPercentage(isNaN(valueAsNumber) ? undefined : valueAsNumber)}
+                    min={0} max={100} precision={2} step={0.01} // Max 100%
+                  >
+                    <NumberInputField placeholder="Enter percentage (e.g., 10 for 10%)" />
+                    <NumberInputStepper>
+                      <NumberIncrementStepper />
+                      <NumberDecrementStepper />
+                    </NumberInputStepper>
+                  </NumberInput>
+              </FormControl>
+            )}
+
+            <FormControl>
+              <FormLabel>Payslip Display Order (Optional)</FormLabel>
+              <NumberInput
+                value={payslipDisplayOrder === undefined || payslipDisplayOrder === null ? '' : payslipDisplayOrder}
+                onChange={(_valueAsString, valueAsNumber) => setPayslipDisplayOrder(isNaN(valueAsNumber) ? undefined : valueAsNumber)}
+                min={0}
+              >
+                <NumberInputField placeholder="e.g., 1, 10, 100" />
+                 <NumberInputStepper>
+                    <NumberIncrementStepper />
+                    <NumberDecrementStepper />
+                </NumberInputStepper>
+              </NumberInput>
+            </FormControl>
+
+            <FormControl display="flex" alignItems="center">
+              <Checkbox
+                isChecked={isTaxable}
+                onChange={(e) => setIsTaxable(e.target.checked)}
+                mr={2}
+              />
+              <FormLabel mb="0">
+                Is this component taxable?
+              </FormLabel>
+            </FormControl>
+          </VStack>
         </ModalBody>
 
         <ModalFooter>
-          <Button colorScheme="blue" mr={3} onClick={handleSubmit}>
-            Save
+          <Button
+            colorScheme="blue"
+            mr={3}
+            onClick={handleSubmit}
+            isDisabled={
+              !name.trim() ||
+              (calculationType === 'fixed' && (amount === undefined || amount === null)) ||
+              (calculationType === 'percentage' && (percentage === undefined || percentage === null))
+            }
+          >
+            Save Component
           </Button>
-          <Button onClick={onClose}>Cancel</Button>
+          <Button variant="ghost" onClick={onClose}>Cancel</Button>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/src/types/salaryComponent.ts
+++ b/src/types/salaryComponent.ts
@@ -26,3 +26,17 @@ export type SalaryComponentPayload = Omit<
   SalaryComponent,
   'id' | 'is_system_defined' | 'tenantId' | 'is_cnss_subject' | 'is_amo_subject' | 'component_code' | 'createdAt' | 'updatedAt' | 'deletedAt'
 >;
+
+// Added SalaryComponentFormData type
+export type SalaryComponentFormData = {
+  name: string;
+  description?: string | null;
+  type: 'earning' | 'deduction';
+  calculation_type: 'fixed' | 'percentage'; // As per specific requirement for FormData
+  amount?: number | null;
+  percentage?: number | null;
+  is_taxable: boolean;
+  is_active: boolean;
+  payslip_display_order?: number | null;
+  // Note: Fields like id, tenantId, is_system_defined etc., are typically excluded from form data for creation/update
+};


### PR DESCRIPTION
This commit incorporates enhancements to both the backend API and the frontend modal for managing salary components with different calculation types.

Backend (from previous commit on feat/salary-component-calculation-types):
- POST /api/salary-components:
    - Accepts `calculation_type`, `amount`, and `percentage`.
    - Dynamically saves `amount` or `percentage` based on `calculation_type`.
    - Validates `calculation_type`.
- PUT /api/salary-components/:componentId:
    - Allows updates to `calculation_type`, `amount`, and `percentage`.
    - Correctly nullifies the non-applicable field (`amount` or `percentage`) when `calculation_type` changes or when `amount`/`percentage` is provided for an incompatible type.
- Unit tests for backend changes are in `backend/salaryComponents.test.js`.

Frontend:
- Type Definitions (`src/types/salaryComponent.ts`):
    - Ensured `SalaryComponent` interface includes `calculation_type: 'fixed' | 'percentage' | 'formula'`.
    - Added `SalaryComponentFormData` type with `calculation_type: 'fixed' | 'percentage'` for the modal.
- SalaryComponentModal (`src/features/salaryComponents/components/SalaryComponentModal.tsx`):
    - Updated to dynamically show/hide "Amount" or "Percentage" fields based on the selected "Calculation Type" ('fixed' or 'percentage').
    - Clears the irrelevant field's state when calculation type changes.
    - Populates correctly when editing existing components with various calculation types (including a fallback for 'formula' from backend).
    - Submits `amount` or `percentage` correctly, nullifying the other, based on the selected calculation type.
    - Uses Chakra UI `NumberInput` for better numeric input UX.
    - Removed the `isCalculatedInCtc` field.
    - Improved overall form structure and state management.