### PR TITLE
fix: Update frontend components to use amount/percentage

### DIFF
--- a/frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
+++ b/frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
@@ -36,7 +36,7 @@ const SalaryComponentList: FC<SalaryComponentListProps> = ({ components, onEdit,
           <Tr>
             <Th>Name</Th>
             <Th>Type</Th>
-            <Th isNumeric>Default Amount</Th>
+            <Th isNumeric>Value</Th>
             <Th>Taxable</Th>
             <Th>Active</Th>
             <Th>Origin</Th>
@@ -49,7 +49,14 @@ const SalaryComponentList: FC<SalaryComponentListProps> = ({ components, onEdit,
               <Td>{component.name}</Td>
               <Td textTransform="capitalize">{component.type}</Td>
               <Td isNumeric>
-                {component.default_amount != null ? component.default_amount.toFixed(2) : 'N/A'}
+                {(() => {
+                  if (component.calculation_type === 'fixed' && component.amount != null) {
+                    return component.amount.toFixed(2);
+                  } else if (component.calculation_type === 'percentage' && component.percentage != null) {
+                    return `${component.percentage.toFixed(2)}%`;
+                  }
+                  return 'N/A';
+                })()}
               </Td>
               <Td>{component.is_taxable ? 'Yes' : 'No'}</Td>
               <Td>

--- a/frontend/src/features/salaryComponents/pages/SalaryComponentsPage.tsx
+++ b/frontend/src/features/salaryComponents/pages/SalaryComponentsPage.tsx
@@ -18,9 +18,9 @@ const SalaryComponentsPage: React.FC = () => {
       setTimeout(() => {
         resolve([
           // Sample data - replace with actual fetched data
-          { id: '1', name: 'Basic Salary', type: 'earning', calculation_type: 'fixed', default_amount: 50000, is_taxable: true, is_system_defined: false, is_active: true },
-          { id: '2', name: 'House Rent Allowance', type: 'earning', calculation_type: 'percentage', default_amount: 40, is_taxable: true, is_system_defined: false, is_active: true },
-          { id: '3', name: 'Provident Fund', type: 'deduction', calculation_type: 'fixed', default_amount: 1800, is_taxable: false, is_system_defined: true, is_active: true },
+          { id: '1', name: 'Basic Salary', type: 'earning', calculation_type: 'fixed', amount: 50000, is_taxable: true, is_system_defined: false, is_active: true, percentage: null },
+          { id: '2', name: 'House Rent Allowance', type: 'earning', calculation_type: 'percentage', percentage: 40, is_taxable: true, is_system_defined: false, is_active: true, amount: null },
+          { id: '3', name: 'Provident Fund', type: 'deduction', calculation_type: 'fixed', amount: 1800, is_taxable: false, is_system_defined: true, is_active: true, percentage: null },
         ]);
       }, 1000);
     });


### PR DESCRIPTION
This commit resolves TypeScript errors caused by the `SalaryComponent` interface change from `default_amount` to separate `amount` and `percentage` fields.

- `frontend/src/features/salaryComponents/components/SalaryComponentList.tsx`:
    - Modified the component to display `component.amount` for 'fixed' calculation types and `component.percentage` (with a '%') for 'percentage' types.
    - Updated the table header from "Default Amount" to "Value".
- `frontend/src/features/salaryComponents/pages/SalaryComponentsPage.tsx`:
    - Updated the sample data to use `amount` for 'fixed' types and `percentage` for 'percentage' types, replacing the old `default_amount` field.
    - Added `null` for the non-applicable field (e.g. `percentage: null` for fixed components) in sample data for better type alignment.