### PR TITLE
fix: Correct db:seed script path in root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "db:seed": "node scripts/seed.js"
+    "db:seed": "node backend/scripts/seed.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The `db:seed` script in the root `package.json` was previously `node scripts/seed.js`. This caused a `MODULE_NOT_FOUND` error because it incorrectly looked for the seed script at `project_root/scripts/seed.js` instead of its actual location at `project_root/backend/scripts/seed.js`.

This commit updates the `db:seed` script to `node backend/scripts/seed.js`, ensuring that `npm run db:seed` (when run from the project root) correctly locates and executes the seed script.