### PR TITLE
fix: Correct dotenv path in seed script for DATABASE_URL

### DIFF
--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -1,6 +1,6 @@
 // scripts/seed.js
-
-require('dotenv').config(); // THIS IS THE MISSING LINE
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
 const { sequelize, Tenant, User, Role, Department, Employee, SalaryComponent, PaySchedule } = require('../models');
 // const bcrypt = require('bcryptjs'); // User model has a hook for password hashing


### PR DESCRIPTION
The seed script (`backend/scripts/seed.js`) was failing with a TypeError because `process.env.DATABASE_URL` was undefined when Sequelize tried to initialize. This was due to `dotenv` not loading the `backend/.env` file correctly when the script was run via `npm run db:seed` from the project root.

This commit updates the `dotenv` configuration in
`backend/scripts/seed.js` to explicitly specify the path to the `.env` file located in the `backend/` directory using `path.resolve(__dirname, '../.env')`.

This ensures that `DATABASE_URL` and other environment variables are correctly loaded before database initialization, allowing the seed script to connect to the database successfully.