### PR TITLE
fix: Adjust unique constraint for component_code in SalaryComponent

### DIFF
--- a/backend/models/salaryComponent.model.js
+++ b/backend/models/salaryComponent.model.js
@@ -109,7 +109,6 @@ module.exports = (sequelize, DataTypes) => {
     component_code: { // For specific system components like 'SALBASE', 'IGR_PRELEV', 'CNSS_COT', 'AMO_COT'
       type: DataTypes.STRING,
       allowNull: true, // Can be null for tenant-defined components
-      unique: true, // Ensures system codes are unique if provided
     },
     is_cnss_subject: { // Does this component contribute to the CNSS taxable base?
       type: DataTypes.BOOLEAN,
@@ -136,6 +135,16 @@ module.exports = (sequelize, DataTypes) => {
       { fields: ['tenant_id'] },
       { unique: true, fields: ['tenant_id', 'name'], name: 'unique_tenant_salary_component_name' },
       // { fields: ['based_on_component_id'] },
+      {
+        unique: true,
+        fields: ['tenant_id', 'component_code'],
+        name: 'unique_tenant_component_code', // Simplified name as Op.ne is not used
+        // where: { // Omitting 'where' clause as Op is not readily available and it's simpler
+        //   component_code: { // This would require Op
+        //     [Op.ne]: null
+        //   }
+        // }
+      }
     ]
   });
 


### PR DESCRIPTION
The seed script was failing with a UniqueConstraintError because `component_code` had a global unique constraint, preventing different tenants from using the same component code (e.g., 'IGR_MONTHLY').

This commit modifies `backend/models/salaryComponent.model.js`:
- Removes the `unique: true` property from the `component_code` field definition.
- Adds a new compound unique index named `unique_tenant_component_code` on the fields `(tenant_id, component_code)`.

This change ensures that `component_code` must be unique only within the scope of a single tenant (if not null), allowing different tenants to reuse common component codes. The `sequelize.sync({ alter: true })` in the seed script will apply this schema change.