### PR TITLE
Fix: Handle non-numeric percentages in SalaryComponentList

### DIFF
--- a/frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
+++ b/frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
@@ -39,7 +39,13 @@ const SalaryComponentList: FC<SalaryComponentListProps> = ({ components, onEdit,
       return component.amount != null ? component.amount.toFixed(2) : 'N/A';
     }
     if (component.calculation_type === 'percentage') {
-      return component.percentage != null ? `${component.percentage.toFixed(2)}%` : 'N/A';
+      if (component.percentage != null) {
+        const numPercentage = parseFloat(String(component.percentage));
+        if (!isNaN(numPercentage)) {
+          return `${numPercentage.toFixed(2)}%`;
+        }
+      }
+      return 'N/A';
     }
     if (component.calculation_type === 'formula') {
       return 'Formula'; // Or some other placeholder


### PR DESCRIPTION
Corrects a TypeError in the `formatAmount` function that occurred when `component.percentage` was not a number. The function now explicitly parses `component.percentage` using `parseFloat` and checks for `NaN` before attempting to call `toFixed()`. This ensures that percentages provided as strings (e.g., from API responses) or invalid values are handled gracefully, defaulting to 'N/A' display.