### PR TITLE
Refactor: Implement robust financial value formatting utility

### DIFF
--- a/frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
+++ b/frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
@@ -1,6 +1,7 @@
 // frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
 import React, { FC } from 'react';
 import { SalaryComponent } from '../../../types'; // Ensure this path is correct
+import formatFinancialValue from '../../../../utils/formatAmount';
 
 import {
   Table,
@@ -33,25 +34,6 @@ const SalaryComponentList: FC<SalaryComponentListProps> = ({ components, onEdit,
     // The parent page (SalaryComponentsPage) might have a more elaborate empty state.
     return null;
   }
-
-  const formatAmount = (component: SalaryComponent): string => {
-    if (component.calculation_type === 'fixed') {
-      return component.amount != null ? component.amount.toFixed(2) : 'N/A';
-    }
-    if (component.calculation_type === 'percentage') {
-      if (component.percentage != null) {
-        const numPercentage = parseFloat(String(component.percentage));
-        if (!isNaN(numPercentage)) {
-          return `${numPercentage.toFixed(2)}%`;
-        }
-      }
-      return 'N/A';
-    }
-    if (component.calculation_type === 'formula') {
-      return 'Formula'; // Or some other placeholder
-    }
-    return 'N/A';
-  };
 
   return (
     <TableContainer bg="white" boxShadow="sm" borderRadius="lg" p={4}>
@@ -89,7 +71,15 @@ const SalaryComponentList: FC<SalaryComponentListProps> = ({ components, onEdit,
               <Td textTransform="capitalize">
                 {component.calculation_type.replace('_', ' ')}
               </Td>
-              <Td fontWeight="medium">{formatAmount(component)}</Td>
+              <Td fontWeight="medium">
+                {component.calculation_type === 'formula'
+                  ? 'Formula'
+                  : formatFinancialValue(
+                      component.calculation_type === 'fixed' ? component.amount : component.percentage,
+                      component.calculation_type, // This will be 'fixed' or 'percentage' here
+                      // currency can be omitted to use default 'USD'
+                    )}
+              </Td>
               <Td>{component.is_taxable ? 'Yes' : 'No'}</Td>
               <Td>
                 {!component.is_system_defined ? (

--- a/frontend/src/utils/formatAmount.ts
+++ b/frontend/src/utils/formatAmount.ts
@@ -1,0 +1,50 @@
+// frontend/src/utils/formatAmount.ts
+
+/**
+ * Formats a financial value either as a currency amount or as a percentage.
+ *
+ * @param value The raw value to format (amount or percentage).
+ * @param calculationType Determines if the value is 'fixed' (amount) or 'percentage'.
+ * @param currency The currency code to use for 'fixed' amounts (e.g., 'USD', 'EUR'). Defaults to 'USD'.
+ * @returns A string representing the formatted value, or a default/fallback string if the input is invalid.
+ */
+const formatFinancialValue = (
+  value: string | number | null | undefined,
+  calculationType: 'fixed' | 'percentage',
+  currency: string = 'USD'
+): string => {
+  if (calculationType === 'percentage') {
+    if (value === null || value === undefined || String(value).trim() === '') {
+      return '0.00%'; // Default for empty or nullish percentage
+    }
+    const numPercentage = parseFloat(String(value));
+    if (typeof numPercentage === 'number' && !isNaN(numPercentage)) {
+      return `${numPercentage.toFixed(2)}%`;
+    }
+    return '0.00%'; // Fallback for unparseable percentage
+  }
+
+  // Handle 'fixed' (amount) type
+  if (value === null || value === undefined || String(value).trim() === '') {
+    // Default for empty or nullish amount: format 0 as currency
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency,
+    }).format(0);
+  }
+  const numAmount = parseFloat(String(value));
+  if (typeof numAmount === 'number' && !isNaN(numAmount)) {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency,
+    }).format(numAmount);
+  }
+
+  // Fallback for unparseable amount: format 0 as currency
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: currency,
+  }).format(0);
+};
+
+export default formatFinancialValue;


### PR DESCRIPTION
Introduces a new utility function `formatFinancialValue` in `frontend/src/utils/formatAmount.ts` to handle the formatting of currency amounts and percentages. This function ensures robust parsing of input values (which may be strings, numbers, null, or undefined), checks for NaN, and provides sensible fallbacks (e.g., "0.00%" or "$0.00"). Fixed amounts are formatted using `Intl.NumberFormat` for proper currency display.

The `SalaryComponentList` component in `frontend/src/features/salaryComponents/components/SalaryComponentList.tsx` has been updated to:
- Remove its local `formatAmount` function.
- Import and use the new `formatFinancialValue` utility.
- Pass the correct `amount` or `percentage` value along with the `calculation_type` to the utility function.
- Continue to display "Formula" directly for components with `calculation_type === 'formula'`.

This change addresses potential TypeError issues if `amount` or `percentage` fields from the API are not strictly numbers (e.g., strings, empty strings, or null) and centralizes formatting logic for better maintainability and reusability.