### PR TITLE
Fix: Correct import path for formatFinancialValue utility

### DIFF
--- a/frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
+++ b/frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
@@ -1,7 +1,7 @@
 // frontend/src/features/salaryComponents/components/SalaryComponentList.tsx
 import React, { FC } from 'react';
 import { SalaryComponent } from '../../../types'; // Ensure this path is correct
-import formatFinancialValue from '../../../../utils/formatAmount';
+import formatFinancialValue from '../../../utils/formatAmount';
 
 import {
   Table,


### PR DESCRIPTION
Updates the import path for the `formatFinancialValue` utility function in `SalaryComponentList.tsx` to correctly resolve to `frontend/src/utils/formatAmount.ts`. The previous path was incorrect due to a miscalculation of relative directory levels, leading to a "Module not found" error in Create React App environments.

The import path for the `SalaryComponent` type was re-verified and confirmed to be correct.