### PR TITLE
feat: Add EmployeeDependent model and associations

### DIFF
--- a/backend/models/employee.model.js
+++ b/backend/models/employee.model.js
@@ -46,6 +46,11 @@ module.exports = (sequelize, DataTypes) => {
         as: 'reportees',
         foreignKey: 'reportingManagerId',
       });
+
+      Employee.hasMany(models.EmployeeDependent, {
+        foreignKey: 'employeeId',
+        as: 'dependents',
+      });
     }
   }
 

--- a/backend/models/employeeDependent.model.js
+++ b/backend/models/employeeDependent.model.js
@@ -1,0 +1,89 @@
+'use strict';
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class EmployeeDependent extends Model {
+    static associate(models) {
+      EmployeeDependent.belongsTo(models.Tenant, {
+        foreignKey: 'tenantId',
+        as: 'tenant',
+        allowNull: false,
+      });
+      EmployeeDependent.belongsTo(models.Employee, {
+        foreignKey: 'employeeId',
+        as: 'employee',
+        allowNull: false,
+      });
+    }
+  }
+
+  EmployeeDependent.init({
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+      allowNull: false,
+    },
+    tenantId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: { model: 'tenants', key: 'id' },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    },
+    employeeId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: { model: 'employees', key: 'id' },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    },
+    full_name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    relationship: {
+      type: DataTypes.ENUM('spouse', 'child', 'other_relative', 'civil_partner'), // Added more options
+      allowNull: false,
+    },
+    date_of_birth: {
+      type: DataTypes.DATEONLY,
+      allowNull: true, // Might not always be known or relevant for all types
+    },
+    // Indicates if this dependent qualifies for fiscal deductions (e.g., IGR relief in Morocco)
+    is_fiscally_dependent: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    // For tracking changes over time, e.g., if a dependent stops being fiscally dependent
+    effective_start_date: {
+      type: DataTypes.DATEONLY,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    effective_end_date: {
+      type: DataTypes.DATEONLY,
+      allowNull: true, // Null means currently effective
+    },
+    // Optional notes, e.g., child with disability for potentially different tax treatment
+    notes: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+    }
+  }, {
+    sequelize,
+    modelName: 'EmployeeDependent',
+    tableName: 'employee_dependents',
+    timestamps: true,
+    paranoid: true, // Soft delete for historical records
+    underscored: true,
+    indexes: [
+      { fields: ['tenant_id'] },
+      { fields: ['employee_id'] },
+      { fields: ['employee_id', 'full_name', 'date_of_birth'], unique: true, name: 'unique_employee_dependent_profile' } // Prevent exact duplicates for an employee
+    ]
+  });
+
+  return EmployeeDependent;
+};

--- a/backend/models/tenant.model.js
+++ b/backend/models/tenant.model.js
@@ -38,6 +38,11 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: 'tenantId',
         as: 'roles',
       });
+
+      Tenant.hasMany(models.EmployeeDependent, {
+        foreignKey: 'tenantId',
+        as: 'tenantDependents',
+      });
     }
   }
   Tenant.init({


### PR DESCRIPTION
This commit introduces the new EmployeeDependent model to store information about an employee's dependents.

Key changes:
- Created `backend/models/employeeDependent.model.js` with the schema for employee dependents, including fields for personal details, relationship type, fiscal dependency status, and effective dates.
- Added a `hasMany` association from the `Employee` model to `EmployeeDependent` (as `dependents`).
- Added a `hasMany` association from the `Tenant` model to `EmployeeDependent` (as `tenantDependents`).
- Verified that `backend/models/index.js` will automatically discover and integrate the new model.