### PR TITLE
Fix: Add UUID validation for employeeId in dependent creation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -305,6 +305,15 @@ app.post('/api/employees/:employeeId/dependents', authenticateAndAttachUser, asy
     try {
         const { tenantId } = req.user;
         const { employeeId } = req.params;
+
+        // Define UUID validation regular expression
+        const UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+
+        // Validate employeeId format
+        if (!UUID_REGEX.test(employeeId)) {
+            return res.status(400).json({ error: 'Invalid employee ID format. Please provide a valid UUID.' });
+        }
+
         const { full_name, relationship, date_of_birth, is_fiscally_dependent, effective_start_date, notes } = req.body;
 
         // Basic validation


### PR DESCRIPTION
The POST /api/employees/:employeeId/dependents route was susceptible to database errors if the provided employeeId was not in a valid UUID format. This change introduces a validation step at the beginning of the route handler.

If the employeeId parameter is not a valid UUID, the API now returns a 400 Bad Request error with a clear message, instead of proceeding to a database query that would fail. This improves error feedback to API clients.

The validation uses a regular expression to check the UUID format. The original error observed was a 'SequelizeDatabaseError' with a PostgreSQL 'invalid input syntax for type uuid' message, caused when querying the Employee model with a non-UUID string.