### PR TITLE
fix: Load environment variables for Jest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Environment variables
 .env
 .env.*
+*.env
 !.env.example  # Keep example env files (if you have them)
 
 # Logs

--- a/backend/jest.setup.js
+++ b/backend/jest.setup.js
@@ -1,4 +1,6 @@
 // backend/jest.setup.js
+require('dotenv').config({ path: './.env' }); // Load .env file from the backend directory
+
 const { sequelize } = require('./models'); // Path relative to backend/
 
 afterAll(async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2134,7 +2134,6 @@
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
This commit resolves an issue where Jest tests were failing due to undefined environment variables (specifically `DATABASE_URL`).

Changes:
- Installed the `dotenv` package.
- Updated `backend/jest.setup.js` to use `dotenv` to load variables from `backend/.env` before tests run. This ensures that database connection strings and other necessary environment configurations are available to the test environment.
- Updated `.gitignore` to include `*.env` to prevent committing any `.env` files.

With these changes, Jest tests should now be able to run correctly by accessing the necessary environment variables defined in `backend/.env`.