### PR TITLE
I updated `backend/__tests__/api.integration.test.js` to include a `s…

### DIFF
--- a/backend/__tests__/api.integration.test.js
+++ b/backend/__tests__/api.integration.test.js
@@ -39,7 +39,7 @@ describe('Payroll SaaS API Integration Tests', () => {
         await sequelize.sync({ force: true });
 
         // Seed data
-        const tenant = await Tenant.create({ name: "TechSolutions Inc.", country: "MA" });
+        const tenant = await Tenant.create({ name: "TechSolutions Inc.", country: "MA", schema_name: "techsolutions_inc" });
         techSolutionsTenantId = tenant.id;
         mockUser.tenantId = tenant.id; // Align mock user with the created tenant
 


### PR DESCRIPTION
…chema_name` when creating the Tenant instance during test data seeding.

This resolves the `SequelizeValidationError: notNull Violation: Tenant.schema_name cannot be null` that occurred after stabilizing the database and Sequelize configuration for tests.