### PR TITLE
Updated backend/__tests__/api.integration.test.js to include an `effe…

### DIFF
--- a/backend/__tests__/api.integration.test.js
+++ b/backend/__tests__/api.integration.test.js
@@ -61,6 +61,7 @@ describe('Payroll SaaS API Integration Tests', () => {
             relationship: "Fils",
             date_of_birth: "2010-05-15",
             is_fiscally_dependent: true,
+            effective_start_date: new Date(), // <-- ADD THIS LINE
             employeeId: ahmedBennaniEmployeeId,
             tenantId: techSolutionsTenantId
         });


### PR DESCRIPTION
…ctive_start_date` when creating the EmployeeDependent instance during test data seeding.

This resolves the `SequelizeValidationError: notNull Violation: EmployeeDependent.effective_start_date cannot be null`.