### PR TITLE
Fix: Correct .env path handling and DATABASE_URL loading

### DIFF
--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -5,9 +5,13 @@ const path = require('path');
 // This ensures DATABASE_URL is available when this config is read.
 require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
+if (!process.env.DATABASE_URL) {
+  throw new Error('DATABASE_URL environment variable is not defined.');
+}
+
 module.exports = {
   "development": {
-    "use_env_variable": "DATABASE_URL",
+    "url": process.env.DATABASE_URL,
     "dialect": "postgres"
   },
   "test": {
@@ -22,7 +26,7 @@ module.exports = {
     "logging": console.log
   },
   "production": {
-    "use_env_variable": "DATABASE_URL",
+    "url": process.env.DATABASE_URL,
     "dialect": "postgres",
     "dialectOptions": {
       "ssl": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,4 +1,3 @@
-require('dotenv').config({ path: require('path').resolve(__dirname, '.env') });
 const express = require('express');
 const path = require('path');
 // User model removed, sequelize kept. Auth middleware imported.


### PR DESCRIPTION
- Updated `backend/config/config.js`:
    - Ensured `dotenv` loads `.env` from the `backend/` directory using an absolute path.
    - Added a check to throw an error if `DATABASE_URL` is not defined after loading `.env`.
    - Changed `development` and `production` environments to directly use `url: process.env.DATABASE_URL`.

- Updated `backend/server.js`:
    - Removed redundant `dotenv.config()` call, as configuration is now centralized in `config/config.js`.

These changes ensure robust and correct loading of environment variables, particularly `DATABASE_URL`, resolving potential startup issues.