### PR TITLE
Fix: Correct index definition in paySchedule.model.js and update comm…

### DIFF
--- a/backend/models/employeeDependent.model.js
+++ b/backend/models/employeeDependent.model.js
@@ -79,9 +79,9 @@ module.exports = (sequelize, DataTypes) => {
     paranoid: true, // Soft delete for historical records
     underscored: true,
     indexes: [
-      { fields: ['tenantId'] }, // DB column name
-      { fields: ['employeeId'] }, // DB column name
-      // DB column names, mapping from model attributes (fullName, dateOfBirth) handled by underscored: true
+      { fields: ['tenantId'] }, // Model attribute name, will be mapped to snake_case by underscored: true
+      { fields: ['employeeId'] }, // Model attribute name, will be mapped to snake_case by underscored: true
+      // Model attribute names, will be mapped to snake_case by underscored: true
       { fields: ['employeeId', 'fullName', 'dateOfBirth'], unique: true, name: 'unique_employee_dependent_profile' }
     ]
   });

--- a/backend/models/paySchedule.model.js
+++ b/backend/models/paySchedule.model.js
@@ -97,8 +97,8 @@ module.exports = (sequelize, DataTypes) => {
     paranoid: true,
     underscored: true,
     indexes: [
-      { fields: ['tenant_id'] }, // DB column name, mapping from tenantId attribute handled by underscored: true
-      { unique: true, fields: ['tenant_id', 'name'], name: 'unique_tenant_payschedule_name' } // Same here
+      { fields: ['tenantId'] }, // Model attribute name, will be mapped to snake_case by underscored: true
+      { unique: true, fields: ['tenantId', 'name'], name: 'unique_tenant_payschedule_name' } // Model attribute names, will be mapped to snake_case by underscored: true
     ]
   });
 


### PR DESCRIPTION
…ents

This commit addresses two issues:

1.  Corrects the index definitions in `backend/models/paySchedule.model.js`. The `fields` in the `indexes` array were using snake_case ('tenant_id') instead of the camelCase model attribute name ('tenantId'). This has been changed to use camelCase, consistent with Sequelize best practices when `underscored: true` is active. Comments for these indexes were also updated to accurately reflect that they refer to model attribute names.

2.  Updates misleading comments in `backend/models/employeeDependent.model.js`. The comments for the indexes were changed to remove the "DB column name" text and clarify that the fields listed are model attribute names, which will be mapped to snake_case in the database by Sequelize.

These changes are intended to resolve `sequelize.sync` errors encountered during testing.