### PR TITLE
Fix: Import PaySchedule model in integration tests

### DIFF
--- a/backend/__tests__/api.integration.test.js
+++ b/backend/__tests__/api.integration.test.js
@@ -1,6 +1,6 @@
 const request = require('supertest');
 const app = require('../server'); // Your refactored app
-const { sequelize, Tenant, User, Department, Employee, EmployeeDependent, SalaryComponent, PayrollRun, Payslip, PayslipItem } = require('../models');
+const { sequelize, Tenant, User, Department, Employee, EmployeeDependent, SalaryComponent, PayrollRun, Payslip, PayslipItem, PaySchedule } = require('../models');
 
 // --- MOCK THE AUTHENTICATION MIDDLEWARE ---
 const mockUser = {


### PR DESCRIPTION
The PaySchedule model was being used in the `beforeAll` hook of `backend/__tests__/api.integration.test.js` without being imported. This caused a Sequelize synchronization error.

This commit adds PaySchedule to the list of imported models from `../models` in the test file.

Note: Verification by running tests was not possible due to `npm install` failures (503 Service Unavailable). I based the fix on the error message and code analysis.