### PR TITLE
Fix: Prevent duplicate index creation for departments

### DIFF
--- a/backend/models/department.model.js
+++ b/backend/models/department.model.js
@@ -64,7 +64,7 @@ module.exports = (sequelize, DataTypes) => {
       // Add a composite unique key for tenantId and name to ensure department names are unique within a tenant
       {
         unique: true,
-        fields: ['tenantId', 'name'] // Use JS model attribute names (camelCase)
+        fields: ['tenant_id', 'name'] // Use JS model attribute names (camelCase)
       }
     ]
   });


### PR DESCRIPTION
The `underscored: true` option in the Department model caused a mismatch between the camelCase field name `tenantId` used in the index definition and the snake_case column name `tenant_id` in the database.

This commit updates the index definition to use `tenant_id`, ensuring Sequelize correctly identifies the existing index and avoids attempting to create a duplicate one.