### PR TITLE
Fix: Correct model definitions for sequelize.sync

### DIFF
--- a/backend/models/department.model.js
+++ b/backend/models/department.model.js
@@ -64,7 +64,7 @@ module.exports = (sequelize, DataTypes) => {
       // Add a composite unique key for tenantId and name to ensure department names are unique within a tenant
       {
         unique: true,
-        fields: ['tenant_id', 'name'] // Use JS model attribute names (camelCase)
+        fields: ['tenantId', 'name'] // CORRECTED: Use camelCase model attribute names
       }
     ]
   });


### PR DESCRIPTION
This commit addresses errors in model definitions that caused issues with `sequelize.sync`:

1.  **`department.model.js`**: The index definition was using `tenant_id` (database column name) instead of `tenantId` (JavaScript model attribute name) in its `fields` array. Corrected to use `tenantId`. Even with `underscored: true`, model attribute names (camelCase) must be used in JavaScript code, including index definitions.

2.  **`payrollRun.model.js`**: Verified that a comma is present after `paranoid: true`. This ensures the `underscored: true` option is correctly applied. (This was previously identified as a potential issue but found to be correct).

3.  **`payslip.model.js`**: Verified that a comma is present after `paranoid: true`. This was fixed in a previous commit (branch: fix/sequelize-sync-and-case-issues) and is confirmed to be correct.

These changes ensure that Sequelize's `underscored: true` option works as expected and that `sequelize.sync` can execute properly.