### PR TITLE
WIP: Correct index fields in EmployeeDependent model for testing

### DIFF
--- a/backend/models/employeeDependent.model.js
+++ b/backend/models/employeeDependent.model.js
@@ -90,10 +90,10 @@ module.exports = (sequelize, DataTypes) => {
     paranoid: true, // Soft delete for historical records
     underscored: true,
     indexes: [
-      { name: 'employee_dependents_tenant_id', fields: ['tenantId'] }, // Updated
-      { name: 'employee_dependents_employee_id_idx', fields: ['employeeId'] }, // Updated
+      { name: 'employee_dependents_tenant_id', fields: ['tenant_id'] }, // Updated
+      { name: 'employee_dependents_employee_id_idx', fields: ['employee_id'] }, // Updated
       // Model attribute names, will be mapped to snake_case by underscored: true
-      { fields: ['employeeId', 'fullName', 'dateOfBirth'], unique: true, name: 'unique_employee_dependent_profile' } // Updated
+      { fields: ['employee_id', 'full_name', 'date_of_birth'], unique: true, name: 'unique_employee_dependent_profile' } // Updated
     ]
   });
 


### PR DESCRIPTION
This commit updates the EmployeeDependent model to use snake_case database column names directly in the `fields` array of its index definitions, while `underscored: true` remains active.

This approach is based on your feedback indicating that Sequelize, in your environment, does not automatically translate model attribute names to column names within index definitions when `underscored: true` is used.

This is an interim commit on a temporary branch (`temp/fix-dependent-model-sync-v2`) to allow you to test these specific changes.