### PR TITLE
Fix: Standardize Sequelize models (Batch 1)

### DIFF
--- a/backend/models/paySchedule.model.js
+++ b/backend/models/paySchedule.model.js
@@ -50,8 +50,11 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
     },
     frequency: { // Defines the pay period frequency
-      type: DataTypes.ENUM('weekly', 'bi_weekly', 'semi_monthly', 'monthly', 'custom'),
+      type: DataTypes.STRING,
       allowNull: false,
+      validate: {
+        isIn: [['weekly', 'bi_weekly', 'semi_monthly', 'monthly', 'custom']],
+      },
     },
     // For weekly/bi-weekly
     payPeriodStartDay: { // e.g., 1 (Monday) to 7 (Sunday) for weekly/bi-weekly
@@ -110,10 +113,10 @@ module.exports = (sequelize, DataTypes) => {
     tableName: 'pay_schedules',
     timestamps: true,
     paranoid: true,
-    // underscored: true, // REMOVED
+    underscored: true,
     indexes: [
-      { name: 'pay_schedules_tenant_id_idx', fields: ['tenant_id'] }, // Updated
-      { unique: true, fields: ['tenant_id', 'name'], name: 'unique_tenant_payschedule_name' } // Updated
+      { name: 'pay_schedules_tenant_id_idx', fields: ['tenantId'] }, // Updated
+      { unique: true, fields: ['tenantId', 'name'], name: 'unique_tenant_payschedule_name' } // Updated
     ]
   });
 

--- a/backend/models/payslipItem.model.js
+++ b/backend/models/payslipItem.model.js
@@ -48,8 +48,11 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
     },
     type: { // To classify the item, e.g., earning, deduction, tax, reimbursement
-      type: DataTypes.ENUM('earning', 'deduction', 'tax', 'reimbursement', 'employer_contribution', 'other'),
+      type: DataTypes.STRING,
       allowNull: false,
+      validate: {
+        isIn: [['earning', 'deduction', 'tax', 'reimbursement', 'employer_contribution', 'other']],
+      },
     },
     amount: {
       type: DataTypes.DECIMAL(12, 2), // Precision 12, 2 decimal places
@@ -70,9 +73,9 @@ module.exports = (sequelize, DataTypes) => {
     underscored: true, // For snake_case column names
     indexes: [
       // FIX: Use snake_case column names when `underscored: true` is set.
-      { fields: ['tenant_id'] },
-      { fields: ['payslip_id'] },
-      { fields: ['salary_component_id'] },
+      { fields: ['tenantId'] },
+      { fields: ['payslipId'] },
+      { fields: ['salaryComponentId'] },
     ]
     // No specific unique indexes here by default, as a payslip can have multiple items of the same type
     // (e.g., multiple "other" earnings or deductions with different descriptions).

--- a/backend/models/salaryComponent.model.js
+++ b/backend/models/salaryComponent.model.js
@@ -62,13 +62,19 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
     },
     type: { // Earning or Deduction
-      type: DataTypes.ENUM('earning', 'deduction'),
+      type: DataTypes.STRING,
       allowNull: false,
+      validate: {
+        isIn: [['earning', 'deduction']],
+      },
     },
     calculationType: { // How the component value is determined
-      type: DataTypes.ENUM('fixed', 'percentage', 'formula'), // 'formula' might need custom logic
+      type: DataTypes.STRING, // 'formula' might need custom logic
       allowNull: false,
       defaultValue: 'fixed',
+      validate: {
+        isIn: [['fixed', 'percentage', 'formula']],
+      },
     },
     amount: { // Fixed amount for 'fixed' type, or default/base amount.
       type: DataTypes.DECIMAL(12, 2), // Precision 12, 2 decimal places
@@ -116,9 +122,12 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: true, // Can be null for tenant-defined components
     },
     category: {
-      type: DataTypes.ENUM('employee_earning', 'employee_deduction', 'employer_contribution_social', 'employer_contribution_other', 'statutory_deduction'),
+      type: DataTypes.STRING,
       allowNull: false,
       defaultValue: 'employee_earning',
+      validate: {
+        isIn: [['employee_earning', 'employee_deduction', 'employer_contribution_social', 'employer_contribution_other', 'statutory_deduction']],
+      },
     },
     isCnssSubject: { // Does this component contribute to the CNSS taxable base?
       type: DataTypes.BOOLEAN,
@@ -144,12 +153,12 @@ module.exports = (sequelize, DataTypes) => {
     // Model attribute names (camelCase) are used in `fields`.
     // Sequelize, with `underscored: true`, maps these to snake_case DB column names.
     indexes: [
-      { fields: ['tenant_id'] },
-      { unique: true, fields: ['tenant_id', 'name'], name: 'unique_tenant_salary_component_name' },
+      { fields: ['tenantId'] },
+      { unique: true, fields: ['tenantId', 'name'], name: 'unique_tenant_salary_component_name' },
       // { fields: ['basedOnComponentId'] }, // basedOnComponentId (model attribute) would map if uncommented
       {
         unique: true,
-        fields: ['tenant_id', 'component_code'], // Model attributes
+        fields: ['tenantId', 'componentCode'], // Model attributes
         name: 'unique_tenant_component_code',
         // where clause referring to componentCode (model attribute) would also be correctly mapped.
       }

--- a/backend/models/tenant.model.js
+++ b/backend/models/tenant.model.js
@@ -62,9 +62,12 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: true,
     },
     status: {
-      type: DataTypes.ENUM('active', 'inactive', 'suspended'),
+      type: DataTypes.STRING,
       defaultValue: 'active',
       allowNull: false,
+      validate: {
+        isIn: [['active', 'inactive', 'suspended']],
+      },
     },
     schemaName: {
       type: DataTypes.STRING,


### PR DESCRIPTION
- Replaced DataTypes.ENUM with DataTypes.STRING and validate.isIn.
- Ensured underscored: true is set.
- Corrected index field names to use camelCase.

Files updated:
- paySchedule.model.js
- payslipItem.model.js
- salaryComponent.model.js
- tenant.model.js